### PR TITLE
Change dependency to django-rest-framework

### DIFF
--- a/doc/guide/cubesviewer-gui-installation.md
+++ b/doc/guide/cubesviewer-gui-installation.md
@@ -44,7 +44,7 @@ CubesViewer application runs on Python/Django. You need to have the following pa
 
 You will also need the following Python packages:
 * requests
-* django-piston
+* django-rest-framework
 
 Django applications can run on local SQLite files, but if you plan to run on a different database system, you may
 need to install also the Python connectors for the appropriate database backend (ie. python-mysqldb).   


### PR DESCRIPTION
django-piston has been replaced with django-rest-framework
https://github.com/jjmontesl/cubesviewer/commit/87216115fdad1584a96a42c6864582d364437bc7