### PR TITLE
Fix error exporting facts to csv

### DIFF
--- a/src/web/static/js/cubesviewer/cubesviewer.views.cube.export.js
+++ b/src/web/static/js/cubesviewer/cubesviewer.views.cube.export.js
@@ -84,7 +84,7 @@ function cubesviewerViewCubeExporter() {
 	 */
 	this.exportFacts = function(view) {
 
-		var params = view.cubesviewer.views.cube.buildQueryParams(view, false, true);
+		var params = view.cubesviewer.views.cube.buildBrowserArgs(view, false, true);
 
 		params["format"] = "csv";
 


### PR DESCRIPTION
When clicking on **View** > **Export facts**, the client raises an exception:

    cubesviewer.views.cube.export.js:87 Uncaught TypeError: undefined is not a function