### PR TITLE
fix utf8 errors when including in a rails app

### DIFF
--- a/src/web/static/js/wiky/wiky.js
+++ b/src/web/static/js/wiky/wiky.js
@@ -16,12 +16,12 @@ var Wiky = {
        "Wiky.rules.post",
      ],
      pre: [
-       { rex:/(\r?\n)/g, tmplt:"\xB6" },  // replace line breaks with '¶' ..
+       { rex:/(\r?\n)/g, tmplt:"\xB6" },  // replace line breaks with 'Â¶' ..
      ],
      post: [
        { rex:/(^\xB6)|(\xB6$)/g, tmplt:"" },  // .. remove linebreaks at BOS and EOS ..
        { rex:/@([0-9]+)@/g, tmplt:function($0,$1){return Wiky.restore($1);} }, // resolve blocks ..
-       { rex:/\xB6/g, tmplt:"\n" } // replace '¶' with line breaks ..
+       { rex:/\xB6/g, tmplt:"\n" } // replace 'Â¶' with line breaks ..
      ],
      nonwikiblocks: [
        { rex:/\\([%])/g, tmplt:function($0,$1){return Wiky.store($1);} },
@@ -96,11 +96,11 @@ var Wiky = {
        "Wiky.inverse.post"
      ],
      pre: [
-       { rex:/(\r?\n)/g, tmplt:"\xB6" }  // replace line breaks with '¶' ..
+       { rex:/(\r?\n)/g, tmplt:"\xB6" }  // replace line breaks with 'Â¶' ..
      ],
      post: [
        { rex:/@([0-9]+)@/g, tmplt:function($0,$1){return Wiky.restore($1);} },  // resolve blocks ..
-       { rex:/\xB6/g, tmplt:"\n" }  // replace '¶' with line breaks ..
+       { rex:/\xB6/g, tmplt:"\n" }  // replace 'Â¶' with line breaks ..
      ],
      nonwikiblocks: [
        { rex:/<pre([^>]*)>(.*?)<\/pre>/mgi, tmplt:function($0,$1,$2){return Wiky.store("["+Wiky.invStyle($1)+Wiky.invAttr($1,["lang"]).replace(/x\-/,"")+"%"+Wiky.apply($2, Wiky.hasAttr($1,"lang")?Wiky.inverse.lang[Wiky.attrVal($1,"lang").substr(2)]:Wiky.inverse.code)+"%]");} } //code block

--- a/src/web/static/js/wiky/wiky.lang.js
+++ b/src/web/static/js/wiky/wiky.lang.js
@@ -22,12 +22,12 @@ Wiky.rules.lang.xml = [
       { rex:/<script([^>]*)>(.*?)<\/script>/g, tmplt:function($0,$1,$2){return "<script"+$1+">"+Wiky.store(Wiky.apply($2, Wiky.rules.lang.js))+"</script>";} }, // script blocks ..
       { rex:/<!\[CDATA\[(.*?)\]\]>/g, tmplt:function($0,$1){return Wiky.store("&lt;![CDATA["+$1+"]]&gt;");} }, // CDATA sections, ..
       { rex:/<!(.*?)>/g, tmplt:function($0,$1){return Wiky.store("<span class=\"cmt\">&lt;!"+$1+"&gt;</span>");} }, // inline xml comments, doctypes, ..
-      { rex:/</g, tmplt:"\xAB"}, // replace '<' by '«'
-      { rex:/>/g, tmplt:"\xBB"}, // replace '>' by '»'
+      { rex:/</g, tmplt:"\xAB"}, // replace '<' by 'Â«'
+      { rex:/>/g, tmplt:"\xBB"}, // replace '>' by 'Â»'
       { rex:/([-A-Za-z0-9_:]+)[ ]*=[ ]*\"(.*?)\"/g, tmplt:"<span class=\"xnam\">$1</span>=<span class=\"xval\">&quot;$2&quot;</span>"}, // "xml attribute value strings ..
       { rex:/(\xAB[\/]?)([-A-Za-z0-9_:]+)/g, tmplt:"$1<span class=\"xtag\">$2</span>"}, // "xml tag ..
-      { rex:/\xAB/g, tmplt:"&lt;"}, // replace '«' by '<'
-      { rex:/\xBB/g, tmplt:"&gt;"}, // replace '»' by '>'
+      { rex:/\xAB/g, tmplt:"&lt;"}, // replace 'Â«' by '<'
+      { rex:/\xBB/g, tmplt:"&gt;"}, // replace 'Â»' by '>'
 ];
 Wiky.inverse.lang.js = [
      { rex:/<span class=\"?(cmt|kwd|mbr|obj|str)\"?>|<\/span>/mgi, tmplt:"" },


### PR DESCRIPTION
When I attempted to include a sparse checkout of the cubesviewer javascript files in my rails app (so I could embed cubesviewer graphs in the rails app), the rails app complained:

    Sprockets::EncodingError at /analysis
    /..../cubesviewer/src/web/static/js/wiky/wiky.js has a invalid UTF-8 byte sequence

Changing the file encoding of two files from latin1 to utf-8 fixed the problem.