### PR TITLE
add default redirect to django auth that doesn't 404

### DIFF
--- a/src/web/cvapp/cvapp/settings.py
+++ b/src/web/cvapp/cvapp/settings.py
@@ -101,6 +101,9 @@ ROOT_URLCONF = 'testing.urls'
 
 WSGI_APPLICATION = 'cvapp.wsgi.application'
 
+# Django auth settings
+LOGIN_REDIRECT_URL = CUBESVIEWER_BACKEND_URL
+
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',


### PR DESCRIPTION
Usually I start the app and go to http://example.com/cubesviewer, which redirects me to http://example.com/accounts/login/?next=/cubesviewer/. That's been great. But sometimes I go directly to http://example.com/accounts/login, and when I log in I get a 404 because I've been redirected to http://example.com/accounts/profile, which doesn't exist.

This fixes that. It's definitely been worth it for me because I've gotten that 404 page like 10 times! :D