### PR TITLE
Allow currency, integer, and number formatting of aggregates

### DIFF
--- a/doc/guide/cubesviewer-model.md
+++ b/doc/guide/cubesviewer-model.md
@@ -130,4 +130,42 @@ in the example below. Ignored dimensions will not be shown by CubesViewer.
         ...
 ```
 
+Aggregate Formatting
+--------------------
 
+You can apply limited formatting options to your aggergates as shown in the
+example below. This will affect the explore view and the series view.
+
+```
+    "aggregates": [
+        {
+            "name": "units_sold_sum",
+            "measure": "units_sold",
+            "function": "sum",
+            "info": {
+                "cv-formatter": "integer"
+            }
+        },
+        {
+            "name": "percentage_sum",
+            "measure": "percentage",
+            "function": "sum",
+            "info": {
+                "cv-formatter": "percent"
+            }
+        },
+        {
+            "name": "revenue_sum",
+            "measure": "revenue",
+            "function": "sum",
+            "info": {
+                "cv-formatter": "currency",
+                "cv-currency-prefix": "",   // defaults to '$'
+                "cv-currency-suffix": "元"  // defaults to ''
+            }
+        }
+    ]
+```
+
+The integer and percent formatters accept no additional options. The currency
+formatter accepts an optional prefix and an optional suffix.

--- a/src/web/static/js/cubesviewer/cubesviewer.views.cube.explore.js
+++ b/src/web/static/js/cubesviewer/cubesviewer.views.cube.explore.js
@@ -171,7 +171,7 @@ function cubesviewerViewCubeExplore() {
 		// Filter selected option (to filter in the values of the selected rows in the Explore table)
 		if (view.params.mode == "explore") {
 			menu.append('<li><a href="#" class="explore-filterselected" ><span class="ui-icon ui-icon-zoomin"></span>Filter selected</a></li>' +
-					    '<div></div>');
+							'<div></div>');
 		}
 
 		// Separator and "clear filters". The datefilter uses this class to place itself in the menu.
@@ -378,6 +378,41 @@ function cubesviewerViewCubeExplore() {
 		};
 	};
 
+	this.aggregateFormatOptions = function(ag) {
+		switch(ag.info['cv-formatter']) {
+		case 'percent':
+			return {
+				formatter: function(cellValue, options, rowObject) {
+					return (cellValue * 100).toFixed(2) + "%";
+				},
+				formatoptions: {},
+			};
+			break;
+		case 'integer':
+			return {
+				formatter: 'integer',
+				formatoptions: { thousandsSeparator: " " }
+			}
+			break;
+		case 'currency':
+			prefix = ag.info['cv-currency-prefix'] === undefined ? '$' : ag.info['cv-currency-prefix'];
+			suffix = ag.info['cv-currency-suffix'] === undefined ? '' : ag.info['cv-currency-suffix'];
+			return {
+				formatter: 'currency',
+				formatoptions: {
+					decimalSeparator: ".",
+					thousandsSeparator: " ",
+					decimalPlaces: 2,
+					prefix: prefix,
+					suffix: suffix
+				}
+			};
+			break;
+		default:
+			return {}; //use defaults
+		}
+	};
+
 	/*
 	 * Show received summary
 	 */
@@ -398,7 +433,7 @@ function cubesviewerViewCubeExplore() {
 
 		$(view.cube.aggregates).each(function(idx, ag) {
 			colNames.push(ag.label);
-			colModel.push({
+			var col = {
 				name : ag.ref,
 				index : ag.ref,
 				align : "right",
@@ -406,8 +441,11 @@ function cubesviewerViewCubeExplore() {
 				width : cubesviewer.views.cube.explore.defineColumnWidth(view, ag.ref, 95),
 				formatter: 'number',
 				cellattr: cubesviewer.views.cube.explore.columnTooltipAttr(ag.ref),
-				formatoptions: { decimalSeparator:".", thousandsSeparator: " ", decimalPlaces: (ag.ref=="record_count" ? 0 : 2)  }
-			});
+				formatoptions: { decimalSeparator:".", thousandsSeparator: " ", decimalPlaces: (ag.ref=="record_count" ? 0 : 2) }
+			};
+
+			$.extend(col, cubesviewer.views.cube.explore.aggregateFormatOptions(ag));
+			colModel.push(col);
 			if (data.summary) dataTotals[ag.ref] = data.summary[ag.ref];
 		});
 
@@ -610,10 +648,10 @@ function cubesviewerViewCubeExplore() {
 		});
 
 		$(view.params.cuts).each(function(idx, e) {
-			var dimparts = view.cube.cvdim_parts(e.dimension.replace(":",  "@"));
+			var dimparts = view.cube.cvdim_parts(e.dimension.replace(":", "@"));
 			var piece = cubesviewer.views.cube.explore.drawInfoPiece(
 				$(view.container).find('.cv-view-viewinfo-cut'), "#ffcccc", 480, readonly,
-				'<span class="ui-icon ui-icon-zoomin"></span> <span><b>Filter: </b> ' + dimparts.label  + ' = ' + '</span>' +
+				'<span class="ui-icon ui-icon-zoomin"></span> <span><b>Filter: </b> ' + dimparts.label + ' = ' + '</span>' +
 				'<span title="' + e.value + '">' + e.value + '</span>'
 			);
 			piece.addClass("cv-view-infopiece-cut");
@@ -673,7 +711,7 @@ function cubesviewerViewCubeExplore() {
 				if (existing_cut.length > 0) {
 					//view.cubesviewer.alert("Cannot cut dataset. Dimension '" + dimension + "' is already filtered.");
 					//return;
-				}  else {*/
+				} else {*/
 					view.params.cuts = $.grep(view.params.cuts, function(e) {
 						return e.dimension == dimension;
 					}, true);

--- a/src/web/static/js/cubesviewer/cubesviewer.views.cube.explore.js
+++ b/src/web/static/js/cubesviewer/cubesviewer.views.cube.explore.js
@@ -378,41 +378,6 @@ function cubesviewerViewCubeExplore() {
 		};
 	};
 
-	this.aggregateFormatOptions = function(ag) {
-		switch(ag.info['cv-formatter']) {
-		case 'percent':
-			return {
-				formatter: function(cellValue, options, rowObject) {
-					return (cellValue * 100).toFixed(2) + "%";
-				},
-				formatoptions: {},
-			};
-			break;
-		case 'integer':
-			return {
-				formatter: 'integer',
-				formatoptions: { thousandsSeparator: " " }
-			}
-			break;
-		case 'currency':
-			prefix = ag.info['cv-currency-prefix'] === undefined ? '$' : ag.info['cv-currency-prefix'];
-			suffix = ag.info['cv-currency-suffix'] === undefined ? '' : ag.info['cv-currency-suffix'];
-			return {
-				formatter: 'currency',
-				formatoptions: {
-					decimalSeparator: ".",
-					thousandsSeparator: " ",
-					decimalPlaces: 2,
-					prefix: prefix,
-					suffix: suffix
-				}
-			};
-			break;
-		default:
-			return {}; //use defaults
-		}
-	};
-
 	/*
 	 * Show received summary
 	 */
@@ -444,7 +409,7 @@ function cubesviewerViewCubeExplore() {
 				formatoptions: { decimalSeparator:".", thousandsSeparator: " ", decimalPlaces: (ag.ref=="record_count" ? 0 : 2) }
 			};
 
-			$.extend(col, cubesviewer.views.cube.explore.aggregateFormatOptions(ag));
+			$.extend(col, cubesviewer.views.cube.columnFormatOptions(ag));
 			colModel.push(col);
 			if (data.summary) dataTotals[ag.ref] = data.summary[ag.ref];
 		});

--- a/src/web/static/js/cubesviewer/cubesviewer.views.cube.js
+++ b/src/web/static/js/cubesviewer/cubesviewer.views.cube.js
@@ -265,6 +265,40 @@ function cubesviewerViewCube () {
 		return cuts;
 	};
 
+	this.columnFormatOptions = function(ag) {
+		switch(ag.info['cv-formatter']) {
+		case 'percent':
+			return {
+				formatter: function(cellValue, options, rowObject) {
+					return (cellValue * 100).toFixed(2) + "%";
+				},
+				formatoptions: {},
+			};
+			break;
+		case 'integer':
+			return {
+				formatter: 'integer',
+				formatoptions: { thousandsSeparator: " " }
+			}
+			break;
+		case 'currency':
+			prefix = ag.info['cv-currency-prefix'] === undefined ? '$' : ag.info['cv-currency-prefix'];
+			suffix = ag.info['cv-currency-suffix'] === undefined ? '' : ag.info['cv-currency-suffix'];
+			return {
+				formatter: 'currency',
+				formatoptions: {
+					decimalSeparator: ".",
+					thousandsSeparator: " ",
+					decimalPlaces: 2,
+					prefix: prefix,
+					suffix: suffix
+				}
+			};
+			break;
+		default:
+			return {}; //use defaults
+		}
+	};
 };
 
 /*

--- a/src/web/static/js/cubesviewer/cubesviewer.views.cube.js
+++ b/src/web/static/js/cubesviewer/cubesviewer.views.cube.js
@@ -47,7 +47,7 @@ function cubesviewerViewCube () {
 		
 		var jqxhr = cubesviewer.cubesserver.get_cube(view.params.cubename, function(cube) {
 			view.cube = cube;
-		    if (view.state == cubesviewer.views.STATE_INITIALIZED) cubesviewer.views.redrawView(view);
+				if (view.state == cubesviewer.views.STATE_INITIALIZED) cubesviewer.views.redrawView(view);
 		});
 		if (jqxhr) {
 			jqxhr.fail(function() {
@@ -270,7 +270,11 @@ function cubesviewerViewCube () {
 		case 'percent':
 			return {
 				formatter: function(cellValue, options, rowObject) {
-					return (cellValue * 100).toFixed(2) + "%";
+					if (cellValue === undefined) {
+						return "---%";
+					} else {
+						return (cellValue * 100).toFixed(2) + "%";
+					}
 				},
 				formatoptions: {},
 			};

--- a/src/web/static/js/cubesviewer/cubesviewer.views.cube.series.js
+++ b/src/web/static/js/cubesviewer/cubesviewer.views.cube.series.js
@@ -257,7 +257,7 @@ function cubesviewerViewCubeSeries() {
 		);
 
 		var colNames = [];
-        var colLabels = [];
+		var colLabels = [];
 		var colModel = [];
 		var dataRows = [];
 		var dataTotals = [];
@@ -266,25 +266,25 @@ function cubesviewerViewCubeSeries() {
 		view.cubesviewer.views.cube.explore._sortData (view, data.cells, view.params.xaxis != null ? true : false);
 		view.cubesviewer.views.cube.series._addRows (view, dataRows, dataTotals, colNames, colModel, data);
 
-        colNames.forEach(function (e) {
-            var colLabel = null;
-            $(view.cube.aggregates).each(function (idx, ag) {
-                if (ag.name == e) {
-                    colLabel = ag.label||ag.name;
-                    return false;
-                }
-            });
-            if (!colLabel) {
-                $(view.cube.measures).each(function (idx, me) {
-                    if (me.name == e) {
-                        colLabel = me.label||ag.name;
-                        return false;
-                    }
-                });
-            }
-            //colLabel = view.cube.getDimension(e).label
-            colLabels.push(colLabel||e);
-        });
+		colNames.forEach(function (e) {
+			var colLabel = null;
+			$(view.cube.aggregates).each(function (idx, ag) {
+				if (ag.name == e) {
+					colLabel = ag.label||ag.name;
+					return false;
+				}
+			});
+			if (!colLabel) {
+				$(view.cube.measures).each(function (idx, me) {
+					if (me.name == e) {
+						colLabel = me.label||ag.name;
+						return false;
+					}
+				});
+			}
+			//colLabel = view.cube.getDimension(e).label
+			colLabels.push(colLabel||e);
+		});
 
 		$('#seriesTable-' + view.id).jqGrid({
 			data: dataRows,
@@ -295,30 +295,30 @@ function cubesviewerViewCubeSeries() {
 			rowList: cubesviewer.options.pagingOptions,
 			colNames: colLabels,
 			colModel: colModel,
-	        pager: "#seriesPager-" + view.id,
-	        sortname: cubesviewer.views.cube.explore.defineColumnSort(view, ["key", "desc"])[0],
-	        viewrecords: true,
-	        sortorder: cubesviewer.views.cube.explore.defineColumnSort(view, ["key", "desc"])[1],
-	        //footerrow: true,
-	        userDataOnFooter: true,
-	        forceFit: false,
-	        shrinkToFit: false,
-	        width: cubesviewer.options.tableResizeHackMinWidth,
-	        //multiselect: true,
-	        //multiboxonly: true,
+			pager: "#seriesPager-" + view.id,
+			sortname: cubesviewer.views.cube.explore.defineColumnSort(view, ["key", "desc"])[0],
+			viewrecords: true,
+			sortorder: cubesviewer.views.cube.explore.defineColumnSort(view, ["key", "desc"])[1],
+			//footerrow: true,
+			userDataOnFooter: true,
+			forceFit: false,
+			shrinkToFit: false,
+			width: cubesviewer.options.tableResizeHackMinWidth,
+			//multiselect: true,
+			//multiboxonly: true,
 
-	        //caption: "Current selection data" ,
-	        beforeSelectRow : function () { return false; },
+			//caption: "Current selection data" ,
+			beforeSelectRow : function () { return false; },
 
 			loadComplete : function() {
 				// Call hook
 				view.cubesviewer.views.cube.explore.onTableLoaded (view);
 			},
 
-	        resizeStop: view.cubesviewer.views.cube.explore._onTableResize (view),
+			resizeStop: view.cubesviewer.views.cube.explore._onTableResize (view),
 			onSortCol: view.cubesviewer.views.cube.explore._onTableSort (view),
 
-	    } );
+		} );
 
 		this.cubesviewer.views.cube._adjustGridSize();
 
@@ -387,11 +387,15 @@ function cubesviewerViewCubeSeries() {
 
 			if (colNames.indexOf(colKey) < 0) {
 				colNames.push (colKey);
-				colModel.push ({
+				var col = {
 					name: colKey, index: colKey, align: "right", sorttype: "number", width: cubesviewer.views.cube.explore.defineColumnWidth(view, colKey, 75),
-			        formatter: 'number',
-			        formatoptions: { decimalSeparator:".", thousandsSeparator: " ", decimalPlaces: 2 }
-				});
+							formatter: 'number',
+							formatoptions: { decimalSeparator:".", thousandsSeparator: " ", decimalPlaces: 2 }
+				};
+
+				var ag = $.grep(view.cube.aggregates, function(ag) { return ag.name == view.params.yaxis })[0];
+				$.extend(col, cubesviewer.views.cube.columnFormatOptions(ag));
+				colModel.push (col);
 			}
 
 


### PR DESCRIPTION
Allows aggregates to include any of the following options:

    "info": {
      "cv-formatter": "integer"
    }
    "info": {
      "cv-formatter": "percent"
    }
    "info": {
      "cv-formatter": "currency",
      "cv-currency-prefix: "",
      "cv-currency-suffix: "元"
    }

The currency formatter prefixes a '$' character by default.