### PR TITLE
sort pie charts by size of slice

### DIFF
--- a/src/web/static/js/cubesviewer/cubesviewer.views.cube.chart.js
+++ b/src/web/static/js/cubesviewer/cubesviewer.views.cube.chart.js
@@ -638,7 +638,7 @@ function cubesviewerViewCubeChart() {
     		}
 
 	    });
-	    d.sort(function(a,b) { return a.key < b.key ? -1 : (a.key > b.key ? +1 : 0) });
+	    d.sort(function(a,b) { return a.y < b.y ? -1 : (a.y > b.y ? +1 : 0) });
 
 	    xticks = [];
 	    for (var i = 1; i < colNames.length; i++) {


### PR DESCRIPTION
This is a pretty simple change, but it makes all pie charts look nicer out of the box.

If this should be configurable instead, I could take a crack at building the configuration option. I just can't imagine where that configuration should go. Is it a button? Is it in the serialized view?

This seems to be a more sensible default than the old behaviour though.